### PR TITLE
Fixed Split horizon with poisoned reverse

### DIFF
--- a/rip.py
+++ b/rip.py
@@ -195,8 +195,8 @@ class Router(object):
         message  = "\nHEADER " + str(self.id) + ' ' + str(output.dest) + '\n'
         message += "ENTRY " + str(self.id) + " 0\n"
         for entry in self.entryTable.getEntries():
-            dest, metric = (entry.dest, entry.metric)
-            if (dest == output.dest): # Split Horizon with Poisoned Reverse
+            dest, metric, first = (entry.dest, entry.metric, entry.first)
+            if (first == output.dest): # Split Horizon with Poisoned Reverse
                 metric = INFINITY
             message += "ENTRY " + str(dest) + ' ' + str(metric) + '\n'
 


### PR DESCRIPTION
I was able to creative a routing loop and this was because the split horizon with poisoned reversed only worked if the destination was the next hop. If the destination was further away than the next hop the positioned reverse did not work.
